### PR TITLE
Fix blog server proxy configuration

### DIFF
--- a/nginx/templates/sites.conf.template
+++ b/nginx/templates/sites.conf.template
@@ -177,10 +177,10 @@ server {
       		proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       		proxy_set_header        X-Forwarded-Proto $scheme;
 
-      		#proxy_pass          http://blog-server:34001;
+      		proxy_pass          http://blog-server:34001;
       		proxy_read_timeout  90;
 
-      		#proxy_redirect      http://blog-server:34001 http://server.blog.ienza.tech;
+      		proxy_redirect      http://blog-server:34001 https://server.blog.ienza.tech;
 
       		# Required for new HTTP-based CLI
       		proxy_http_version 1.1;


### PR DESCRIPTION
🐛 Issue: Admin editor failing with 'ERR_CERT_DATE_INVALID'
- nginx was not proxying requests to blog-server container
- server.blog.ienza.tech had proxy_pass commented out
- API requests were failing with SSL certificate errors

✅ Solution: Enable nginx proxy for server.blog.ienza.tech
- Uncommented proxy_pass http://blog-server:34001
- Updated proxy_redirect to use HTTPS for proper redirects
- Requests to https://server.blog.ienza.tech now proxy to blog-server:34001

🎯 Expected result:
- Admin editor API calls work correctly ✅
- Blog post submission connects to database ✅
- SSL certificate issues resolved ✅