### PR TITLE
Remove nginx CORS header to fix duplicate header conflict

### DIFF
--- a/nginx/templates/sites.conf.template
+++ b/nginx/templates/sites.conf.template
@@ -169,7 +169,7 @@ server {
 
 	server_name server.blog.ienza.tech;
 
-	add_header Access-Control-Allow-Origin *;
+	# add_header Access-Control-Allow-Origin *; # CORS will be handled by the blog-server
 
 	location / {
 		proxy_set_header        Host $host:$server_port;


### PR DESCRIPTION
🐛 Issue: CORS failing with duplicate Access-Control-Allow-Origin headers
- nginx was adding: Access-Control-Allow-Origin: *
- blog-server was adding: Access-Control-Allow-Origin: http://localhost:4200
- Browser rejected: only one header allowed

✅ Solution: Comment out nginx CORS header
- Let blog-server handle CORS properly
- Eliminates duplicate header conflict
- Works with blog-server's origin array configuration

Ready for blog-server CORS update to include production origin.